### PR TITLE
feat: update work experience with new role at Sirine.ai

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ I'm a Full-Stack Web Developer from Chennai, 🇮🇳 India. I specialize in cre
 
 ## 📈 Github Stats (Past Year)
 
-- Total Commits: 638
+- Total Commits: 632
 - Total Stars: 85
-- Total PRs: 1377
+- Total PRs: 1382
 - Total Contributions: 16
 - Total Issues: 115
 
@@ -28,10 +28,16 @@ I'm a Full-Stack Web Developer from Chennai, 🇮🇳 India. I specialize in cre
 <details>
   <summary>Experience (8 years)</summary>
 
+  #### Sirine.ai B.V
+  *Full Stack Engineer*
+
+  <sup>Jul 2025 - Present (1 m) • India</sup>
+
+  ---
   #### Oreala B.V
   *Full Stack Engineer*
 
-  <sup>Apr 2022 - Present (3 yr, 4 m) • India</sup>
+  <sup>Apr 2022 - Jun 2025 (3 yr, 2 m) • India</sup>
 
   ---
   #### Colan Infotech Private Limited

--- a/data/experience.json
+++ b/data/experience.json
@@ -1,10 +1,17 @@
 {
   "experience": [
     {
+      "company": "Sirine.ai B.V",
+      "role": "Full Stack Engineer",
+      "startDate": "2025-07",
+      "isCurrent": true,
+      "location": "India"
+    },
+    {
       "company": "Oreala B.V",
       "role": "Full Stack Engineer",
       "startDate": "2022-04",
-      "isCurrent": true,
+      "endDate": "2025-06",
       "location": "India"
     },
     {


### PR DESCRIPTION
## Summary
- Add new current position at Sirine.ai B.V as Full Stack Engineer (Jul 2025 - Present)
- Update Oreala B.V role to ended in Jun 2025  
- Update GitHub stats to reflect recent activity

## Test plan
- [x] Verify README.md displays new experience correctly
- [x] Confirm experience.json has updated data structure
- [x] Check that formatting and dates are accurate