### PR TITLE
Migrate domain from xqsit94.in to xqsit.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ I'm a Full-Stack Web Developer from Chennai, 🇮🇳 India. I specialize in cre
 
 ## 🤝 Connect with me
 
-- Personal Website: https://xqsit94.in
+- Personal Website: https://xqsit.dev
 - LinkedIn: https://www.linkedin.com/in/xqsit94
 - Github: https://github.com/xqsit94
 

--- a/internal/posts/posts.go
+++ b/internal/posts/posts.go
@@ -15,7 +15,7 @@ type Post struct {
 
 func GetPosts() ([]Post, error) {
 	fp := gofeed.NewParser()
-	feed, err := fp.ParseURL("https://xqsit94.in/rss.xml")
+	feed, err := fp.ParseURL("https://xqsit.dev/rss.xml")
 	if err != nil {
 		return nil, err
 	}

--- a/templates/README.tmpl
+++ b/templates/README.tmpl
@@ -4,7 +4,7 @@ I'm a Full-Stack Web Developer from Chennai, 🇮🇳 India. I specialize in cre
 
 ## 🤝 Connect with me
 
-- Personal Website: https://xqsit94.in
+- Personal Website: https://xqsit.dev
 - LinkedIn: https://www.linkedin.com/in/xqsit94
 - Github: https://github.com/xqsit94
 


### PR DESCRIPTION
## Summary
- Updated personal website URL from `xqsit94.in` to `xqsit.dev` across README, README template, and RSS feed URL