### PR TITLE
✨ Configurable + animated ASCII portrait color (yellow/gray/cycle)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,26 +7,11 @@
 </p>
 
 <p align="center">
-  <a href="https://xqsit.dev">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="./assets/btn_website_dark.svg" />
-      <img alt="xqsit.dev" src="./assets/btn_website_light.svg" height="32" />
-    </picture>
-  </a>
+  <a href="https://xqsit.dev"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/btn_website_dark.svg" /><img alt="xqsit.dev" src="./assets/btn_website_light.svg" height="32" /></picture></a>
   &nbsp;
-  <a href="https://www.linkedin.com/in/xqsit94">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="./assets/btn_linkedin_dark.svg" />
-      <img alt="LinkedIn" src="./assets/btn_linkedin_light.svg" height="32" />
-    </picture>
-  </a>
+  <a href="https://www.linkedin.com/in/xqsit94"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/btn_linkedin_dark.svg" /><img alt="LinkedIn" src="./assets/btn_linkedin_light.svg" height="32" /></picture></a>
   &nbsp;
-  <a href="mailto:manikandan@xqsit.dev">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="./assets/btn_email_dark.svg" />
-      <img alt="Email" src="./assets/btn_email_light.svg" height="32" />
-    </picture>
-  </a>
+  <a href="mailto:manikandan@xqsit.dev"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/btn_email_dark.svg" /><img alt="Email" src="./assets/btn_email_light.svg" height="32" /></picture></a>
 </p>
 
 <details>

--- a/assets/dark_mode.svg
+++ b/assets/dark_mode.svg
@@ -1,9 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="976" height="669" viewBox="0 0 976 669" font-family="'SFMono-Regular','SF Mono',Consolas,'Liberation Mono',Menlo,monospace" role="img" aria-label="manikandan@xqsit.dev — git fetch profile card">
-<style>@keyframes blink{50%{opacity:0}}.cur{animation:blink 1.1s step-end infinite}@keyframes fin{from{opacity:0}to{opacity:1}}.fade{animation:fin .8s ease both}.tk{fill:#d2a8ff;font-weight:700}.sk{fill:#e3b341}.ar{fill:#56d4dd}.br{fill:#39929e}.vl{fill:#adbac7}text,tspan{white-space:pre}</style>
-<defs><linearGradient id="pg" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#f47067"/><stop offset="0.5" stop-color="#d2a8ff"/><stop offset="1" stop-color="#6cb6ff"/></linearGradient></defs>
-<rect x="0.5" y="0.5" width="975" height="668" rx="12" fill="#0d1117" stroke="#30363d"/>
+<style>@keyframes blink{50%{opacity:0}}.cur{animation:blink 1.1s step-end infinite}@keyframes fin{from{opacity:0}to{opacity:1}}.fade{animation:fin .8s ease both}.tk{fill:#d2a8ff;font-weight:700}.sk{fill:#e3b341}.ar{fill:#56d4dd}.br{fill:#39929e}.vl{fill:#adbac7}text,tspan{white-space:pre}@keyframes pgc{0%,100%{opacity:0}50%{opacity:1}}.pgc{animation:pgc 9s ease-in-out infinite}@media (prefers-reduced-motion:reduce){.pgc{animation:none;opacity:0}}</style>
+<defs><linearGradient id="pgY" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#ffdf5d"/><stop offset="0.5" stop-color="#e3b341"/><stop offset="1" stop-color="#d29922"/></linearGradient><linearGradient id="pgG" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#f0f6fc"/><stop offset="0.5" stop-color="#c9d1d9"/><stop offset="1" stop-color="#8b949e"/></linearGradient></defs>
+<rect x="0.5" y="0.5" width="975" height="668" rx="6" fill="#0d1117" stroke="#30363d"/>
 <text x="30" y="45.0" font-size="15"><tspan fill="#56d4dd" font-weight="700">~ </tspan><tspan fill="#57ab5a" font-weight="700">❯ </tspan><tspan fill="#e3b341">git</tspan><tspan fill="#adbac7"> fetch</tspan></text>
-<g class="fade" fill="url(#pg)" font-size="12">
+<g class="fade" font-size="12">
+<g fill="url(#pgY)">
 <text x="30" y="100.1">                     .`.      `&#39;&#39;...``..</text>
 <text x="30" y="113.5">                 .&#39;&#39;::&#39;.   ..&#39;:&#39;&#39;;  ``...````</text>
 <text x="30" y="126.9">            .`..::.:&#39;&#39;`. .````..`*   .     ..`&#39;:`</text>
@@ -45,6 +46,49 @@
 <text x="30" y="609.2">                        #;****!;;&#39;`.                :M:!&#39;  `::!:</text>
 <text x="30" y="622.6">                     .;#*!`;;:`                    &#39;M*!`  &#39;:   .</text>
 </g>
+<g class="pgc" fill="url(#pgG)" opacity="0">
+<text x="30" y="100.1">                     .`.      `&#39;&#39;...``..</text>
+<text x="30" y="113.5">                 .&#39;&#39;::&#39;.   ..&#39;:&#39;&#39;;  ``...````</text>
+<text x="30" y="126.9">            .`..::.:&#39;&#39;`. .````..`*   .     ..`&#39;:`</text>
+<text x="30" y="140.3">          &#39;!:`.&#39;` :*;;&#39;`..      ;; .&#39;:&#39;.       .::.</text>
+<text x="30" y="153.7">         :#`` &#39;.  ##:`&#39;&#39;       `:````&#39;::         &#39;!`</text>
+<text x="30" y="167.1">      ` &#39;#`:&#39;&#39;&#39; . *;.*;...    .`... .:;     ..`.  .&#39;:&#39;.</text>
+<text x="30" y="180.5">      ;.;! &#39;!;:&#39;&#39;&#39;:.*#&#39;::&#39;;;:::&#39;.  `::   ...`::     `:;.</text>
+<text x="30" y="193.9">     .!::*. &#39;**;;:*;!#!*!*W#!:&#39;&#39;&#39;:!*:``. ..&#39;;&#39;      .`:!</text>
+<text x="30" y="207.3">     &#39;&#39;`;*;``&#39;;**#*W#W#W#W*;!!!*#W*;&#39;`.`````   `&#39;`.  .&#39;!;</text>
+<text x="30" y="220.7">    .`;&#39;&#39;!#W!**!**;:;::&#39;&#39;` ..    `&#39;:;**!;:&#39;&#39;:;;:`   ..`&#39;*:</text>
+<text x="30" y="234.1">      &#39;;;;*#$#;`                     `;!*W#!;:`.     &#39;:&#39;;*</text>
+<text x="30" y="247.5">     .&#39;;&#39;:!M*                          .`:*#*!;:`.`. .:!;#</text>
+<text x="30" y="260.9">      ;W!;W#                              `*!&#39;&#39;&#39;`..&#39;``&#39;!!*</text>
+<text x="30" y="274.3">     .;W!;M`                               &#39;!` .``..:&#39;:;*;</text>
+<text x="30" y="287.7">      &#39;M!!W                                 :#!`.  .&#39;;::W:</text>
+<text x="30" y="301.1">       W!!#                  ....````&#39;:&#39;.     !W;&#39;.&#39;&#39;&#39;;;#`</text>
+<text x="30" y="314.4">       `#M!.`..`..        .:#@@@$@@M#!*#!&#39;``.  :W!::;;:!M.</text>
+<text x="30" y="327.8">        :@M$@@@@$$M*&#39;     !@@$MW#!;::&#39;&#39;:!!!@M!;&#39;;;;;**!##</text>
+<text x="30" y="341.2">      `:!M@$****WWMM#!;:`!M#;:!#**!***;`:*#:&#39;;*!!;*MW&#39;!#!</text>
+<text x="30" y="354.6">     $@@$*W:&#39;!!!*#MMMM@M*WM  ;W*&#39;#$MW!#` W*     &#39;*MW.;::*`</text>
+<text x="30" y="368.0">     ;$$;*M`W@:;$MW;#WM``*@#  &#39;:`..      M;      !W.*. .&#39;&#39;</text>
+<text x="30" y="381.4">      &#39;@` ;`&#39;!&#39;..   &#39;$`   *@!   ..      &#39;@.      *#!*` `&#39;`</text>
+<text x="30" y="394.8">       *M &#39;&#39;        M#     ;$*.       `;M:       *;&#39;.  `*</text>
+<text x="30" y="408.2">        W*;&#39;     .&#39;W@.      `*#**!!!;;;:.        `.;&#39;.`!;</text>
+<text x="30" y="421.6">         :W#!!!!*###:         &#39;.``..             . ;..`:.</text>
+<text x="30" y="435.0">          &#39;;... . .:;;   :;;:.:.                 ..   `;</text>
+<text x="30" y="448.4">           !.      ;W$M!!;``::&#39;                  `#;&#39;&#39;:</text>
+<text x="30" y="461.8">           &#39;`       `;;`                         ;M$;</text>
+<text x="30" y="475.2">            :      .     `                      &#39;*!*</text>
+<text x="30" y="488.6">            &#39;;   `&#39;:;!;;;&#39;&#39;:&#39;:!!;;:            .;#&#39;;</text>
+<text x="30" y="502.0">             !&#39; ...!M#&#39;.``.    ...            .`W&#39;&#39;;</text>
+<text x="30" y="515.4">              !&#39;     ``&#39;&#39;&#39;::`.              .`;W! `;</text>
+<text x="30" y="528.8">              `*&#39;`    `:!*!;`        .     `:*W:  .!</text>
+<text x="30" y="542.2">               .!*;.                 ...`&#39;:#W*.    #`</text>
+<text x="30" y="555.6">                 :W*`                ``;*##!&#39;.     &#39;*.</text>
+<text x="30" y="569.0">                  `##:.           .`;*#W*;&#39;.       .`W!`.</text>
+<text x="30" y="582.4">                    :WW*:&#39;&#39;&#39;::;:!!#MWW!```.        . :@#M*;`</text>
+<text x="30" y="595.8">                      &#39;!MM$MMMM$MW#!;&#39;.              ## W`.!!&#39;</text>
+<text x="30" y="609.2">                        #;****!;;&#39;`.                :M:!&#39;  `::!:</text>
+<text x="30" y="622.6">                     .;#*!`;;:`                    &#39;M*!`  &#39;:   .</text>
+</g>
+</g>
 <g font-size="15">
 <text x="538" y="82.0" font-weight="700"><tspan fill="#f47067">manikandan</tspan><tspan fill="#7d8590">@</tspan><tspan fill="#6cb6ff">xqsit.dev</tspan></text>
 <rect class="cur" x="723.1" y="70.0" width="8.2" height="14.0" fill="#f47067"/>
@@ -61,7 +105,7 @@
 <text x="538" y="369.1"><tspan class="br"> ├ </tspan><tspan class="sk">Frameworks</tspan><tspan class="ar"> → </tspan><tspan class="vl">Laravel · Vue.js · Adonis</tspan></text>
 <text x="538" y="392.1"><tspan class="br"> └ </tspan><tspan class="sk">AI</tspan><tspan class="ar"> → </tspan><tspan class="vl">LLM · Agents · MCP · RAG</tspan></text>
 <text x="538" y="438.1"><tspan class="tk">STATS</tspan><tspan class="ar"> → </tspan><tspan class="vl">Past Year</tspan></text>
-<text x="538" y="461.1"><tspan class="br"> └ </tspan><tspan class="vl">1,429</tspan><tspan class="sk"> commits</tspan><tspan class="br">  ·  </tspan><tspan class="vl">2,555</tspan><tspan class="sk"> PRs</tspan><tspan class="br">  ·  </tspan><tspan class="vl">133</tspan><tspan class="sk"> stars</tspan></text>
+<text x="538" y="461.1"><tspan class="br"> └ </tspan><tspan class="vl">1,458</tspan><tspan class="sk"> commits</tspan><tspan class="br">  ·  </tspan><tspan class="vl">2,589</tspan><tspan class="sk"> PRs</tspan><tspan class="br">  ·  </tspan><tspan class="vl">136</tspan><tspan class="sk"> stars</tspan></text>
 <text x="538" y="507.1"><tspan class="tk">EDU</tspan><tspan class="ar"> → </tspan><tspan class="vl">Madha Engineering College</tspan></text>
 <text x="538" y="530.1"><tspan class="br"> └ </tspan><tspan class="sk">Degree</tspan><tspan class="ar"> → </tspan><tspan class="vl">B.E. Computer Science</tspan></text>
 <text x="538" y="576.1"><tspan class="tk">WWW</tspan><tspan class="ar"> → </tspan><tspan class="vl">Links</tspan></text>

--- a/assets/light_mode.svg
+++ b/assets/light_mode.svg
@@ -1,9 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="976" height="669" viewBox="0 0 976 669" font-family="'SFMono-Regular','SF Mono',Consolas,'Liberation Mono',Menlo,monospace" role="img" aria-label="manikandan@xqsit.dev — git fetch profile card">
-<style>@keyframes blink{50%{opacity:0}}.cur{animation:blink 1.1s step-end infinite}@keyframes fin{from{opacity:0}to{opacity:1}}.fade{animation:fin .8s ease both}.tk{fill:#8250df;font-weight:700}.sk{fill:#9a6700}.ar{fill:#1b7c83}.br{fill:#1b7c83}.vl{fill:#24292f}text,tspan{white-space:pre}</style>
-<defs><linearGradient id="pg" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#cf222e"/><stop offset="0.5" stop-color="#8250df"/><stop offset="1" stop-color="#0969da"/></linearGradient></defs>
-<rect x="0.5" y="0.5" width="975" height="668" rx="12" fill="#ffffff" stroke="#d0d7de"/>
+<style>@keyframes blink{50%{opacity:0}}.cur{animation:blink 1.1s step-end infinite}@keyframes fin{from{opacity:0}to{opacity:1}}.fade{animation:fin .8s ease both}.tk{fill:#8250df;font-weight:700}.sk{fill:#9a6700}.ar{fill:#1b7c83}.br{fill:#1b7c83}.vl{fill:#24292f}text,tspan{white-space:pre}@keyframes pgc{0%,100%{opacity:0}50%{opacity:1}}.pgc{animation:pgc 9s ease-in-out infinite}@media (prefers-reduced-motion:reduce){.pgc{animation:none;opacity:0}}</style>
+<defs><linearGradient id="pgY" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#d4a72c"/><stop offset="0.5" stop-color="#bf8700"/><stop offset="1" stop-color="#9a6700"/></linearGradient><linearGradient id="pgG" x1="0" y1="0" x2="0" y2="1"><stop offset="0" stop-color="#57606a"/><stop offset="0.5" stop-color="#424a53"/><stop offset="1" stop-color="#24292f"/></linearGradient></defs>
+<rect x="0.5" y="0.5" width="975" height="668" rx="6" fill="#ffffff" stroke="#d0d7de"/>
 <text x="30" y="45.0" font-size="15"><tspan fill="#1b7c83" font-weight="700">~ </tspan><tspan fill="#1a7f37" font-weight="700">❯ </tspan><tspan fill="#9a6700">git</tspan><tspan fill="#24292f"> fetch</tspan></text>
-<g class="fade" fill="url(#pg)" font-size="12">
+<g class="fade" font-size="12">
+<g fill="url(#pgY)">
 <text x="30" y="100.1">                     .`.      `&#39;&#39;...``..</text>
 <text x="30" y="113.5">                 .&#39;&#39;::&#39;.   ..&#39;:&#39;&#39;;  ``...````</text>
 <text x="30" y="126.9">            .`..::.:&#39;&#39;`. .````..`*   .     ..`&#39;:`</text>
@@ -45,6 +46,49 @@
 <text x="30" y="609.2">                        #;****!;;&#39;`.                :M:!&#39;  `::!:</text>
 <text x="30" y="622.6">                     .;#*!`;;:`                    &#39;M*!`  &#39;:   .</text>
 </g>
+<g class="pgc" fill="url(#pgG)" opacity="0">
+<text x="30" y="100.1">                     .`.      `&#39;&#39;...``..</text>
+<text x="30" y="113.5">                 .&#39;&#39;::&#39;.   ..&#39;:&#39;&#39;;  ``...````</text>
+<text x="30" y="126.9">            .`..::.:&#39;&#39;`. .````..`*   .     ..`&#39;:`</text>
+<text x="30" y="140.3">          &#39;!:`.&#39;` :*;;&#39;`..      ;; .&#39;:&#39;.       .::.</text>
+<text x="30" y="153.7">         :#`` &#39;.  ##:`&#39;&#39;       `:````&#39;::         &#39;!`</text>
+<text x="30" y="167.1">      ` &#39;#`:&#39;&#39;&#39; . *;.*;...    .`... .:;     ..`.  .&#39;:&#39;.</text>
+<text x="30" y="180.5">      ;.;! &#39;!;:&#39;&#39;&#39;:.*#&#39;::&#39;;;:::&#39;.  `::   ...`::     `:;.</text>
+<text x="30" y="193.9">     .!::*. &#39;**;;:*;!#!*!*W#!:&#39;&#39;&#39;:!*:``. ..&#39;;&#39;      .`:!</text>
+<text x="30" y="207.3">     &#39;&#39;`;*;``&#39;;**#*W#W#W#W*;!!!*#W*;&#39;`.`````   `&#39;`.  .&#39;!;</text>
+<text x="30" y="220.7">    .`;&#39;&#39;!#W!**!**;:;::&#39;&#39;` ..    `&#39;:;**!;:&#39;&#39;:;;:`   ..`&#39;*:</text>
+<text x="30" y="234.1">      &#39;;;;*#$#;`                     `;!*W#!;:`.     &#39;:&#39;;*</text>
+<text x="30" y="247.5">     .&#39;;&#39;:!M*                          .`:*#*!;:`.`. .:!;#</text>
+<text x="30" y="260.9">      ;W!;W#                              `*!&#39;&#39;&#39;`..&#39;``&#39;!!*</text>
+<text x="30" y="274.3">     .;W!;M`                               &#39;!` .``..:&#39;:;*;</text>
+<text x="30" y="287.7">      &#39;M!!W                                 :#!`.  .&#39;;::W:</text>
+<text x="30" y="301.1">       W!!#                  ....````&#39;:&#39;.     !W;&#39;.&#39;&#39;&#39;;;#`</text>
+<text x="30" y="314.4">       `#M!.`..`..        .:#@@@$@@M#!*#!&#39;``.  :W!::;;:!M.</text>
+<text x="30" y="327.8">        :@M$@@@@$$M*&#39;     !@@$MW#!;::&#39;&#39;:!!!@M!;&#39;;;;;**!##</text>
+<text x="30" y="341.2">      `:!M@$****WWMM#!;:`!M#;:!#**!***;`:*#:&#39;;*!!;*MW&#39;!#!</text>
+<text x="30" y="354.6">     $@@$*W:&#39;!!!*#MMMM@M*WM  ;W*&#39;#$MW!#` W*     &#39;*MW.;::*`</text>
+<text x="30" y="368.0">     ;$$;*M`W@:;$MW;#WM``*@#  &#39;:`..      M;      !W.*. .&#39;&#39;</text>
+<text x="30" y="381.4">      &#39;@` ;`&#39;!&#39;..   &#39;$`   *@!   ..      &#39;@.      *#!*` `&#39;`</text>
+<text x="30" y="394.8">       *M &#39;&#39;        M#     ;$*.       `;M:       *;&#39;.  `*</text>
+<text x="30" y="408.2">        W*;&#39;     .&#39;W@.      `*#**!!!;;;:.        `.;&#39;.`!;</text>
+<text x="30" y="421.6">         :W#!!!!*###:         &#39;.``..             . ;..`:.</text>
+<text x="30" y="435.0">          &#39;;... . .:;;   :;;:.:.                 ..   `;</text>
+<text x="30" y="448.4">           !.      ;W$M!!;``::&#39;                  `#;&#39;&#39;:</text>
+<text x="30" y="461.8">           &#39;`       `;;`                         ;M$;</text>
+<text x="30" y="475.2">            :      .     `                      &#39;*!*</text>
+<text x="30" y="488.6">            &#39;;   `&#39;:;!;;;&#39;&#39;:&#39;:!!;;:            .;#&#39;;</text>
+<text x="30" y="502.0">             !&#39; ...!M#&#39;.``.    ...            .`W&#39;&#39;;</text>
+<text x="30" y="515.4">              !&#39;     ``&#39;&#39;&#39;::`.              .`;W! `;</text>
+<text x="30" y="528.8">              `*&#39;`    `:!*!;`        .     `:*W:  .!</text>
+<text x="30" y="542.2">               .!*;.                 ...`&#39;:#W*.    #`</text>
+<text x="30" y="555.6">                 :W*`                ``;*##!&#39;.     &#39;*.</text>
+<text x="30" y="569.0">                  `##:.           .`;*#W*;&#39;.       .`W!`.</text>
+<text x="30" y="582.4">                    :WW*:&#39;&#39;&#39;::;:!!#MWW!```.        . :@#M*;`</text>
+<text x="30" y="595.8">                      &#39;!MM$MMMM$MW#!;&#39;.              ## W`.!!&#39;</text>
+<text x="30" y="609.2">                        #;****!;;&#39;`.                :M:!&#39;  `::!:</text>
+<text x="30" y="622.6">                     .;#*!`;;:`                    &#39;M*!`  &#39;:   .</text>
+</g>
+</g>
 <g font-size="15">
 <text x="538" y="82.0" font-weight="700"><tspan fill="#cf222e">manikandan</tspan><tspan fill="#57606a">@</tspan><tspan fill="#0969da">xqsit.dev</tspan></text>
 <rect class="cur" x="723.1" y="70.0" width="8.2" height="14.0" fill="#cf222e"/>
@@ -61,7 +105,7 @@
 <text x="538" y="369.1"><tspan class="br"> ├ </tspan><tspan class="sk">Frameworks</tspan><tspan class="ar"> → </tspan><tspan class="vl">Laravel · Vue.js · Adonis</tspan></text>
 <text x="538" y="392.1"><tspan class="br"> └ </tspan><tspan class="sk">AI</tspan><tspan class="ar"> → </tspan><tspan class="vl">LLM · Agents · MCP · RAG</tspan></text>
 <text x="538" y="438.1"><tspan class="tk">STATS</tspan><tspan class="ar"> → </tspan><tspan class="vl">Past Year</tspan></text>
-<text x="538" y="461.1"><tspan class="br"> └ </tspan><tspan class="vl">1,429</tspan><tspan class="sk"> commits</tspan><tspan class="br">  ·  </tspan><tspan class="vl">2,555</tspan><tspan class="sk"> PRs</tspan><tspan class="br">  ·  </tspan><tspan class="vl">133</tspan><tspan class="sk"> stars</tspan></text>
+<text x="538" y="461.1"><tspan class="br"> └ </tspan><tspan class="vl">1,458</tspan><tspan class="sk"> commits</tspan><tspan class="br">  ·  </tspan><tspan class="vl">2,589</tspan><tspan class="sk"> PRs</tspan><tspan class="br">  ·  </tspan><tspan class="vl">136</tspan><tspan class="sk"> stars</tspan></text>
 <text x="538" y="507.1"><tspan class="tk">EDU</tspan><tspan class="ar"> → </tspan><tspan class="vl">Madha Engineering College</tspan></text>
 <text x="538" y="530.1"><tspan class="br"> └ </tspan><tspan class="sk">Degree</tspan><tspan class="ar"> → </tspan><tspan class="vl">B.E. Computer Science</tspan></text>
 <text x="538" y="576.1"><tspan class="tk">WWW</tspan><tspan class="ar"> → </tspan><tspan class="vl">Links</tspan></text>

--- a/cmd/cards/main.go
+++ b/cmd/cards/main.go
@@ -17,6 +17,7 @@ func main() {
 	d := card.Assemble(profile.GetProfile(), profile.GetExperience(),
 		profile.GetEducation(), profile.CalculateTotalExperience(),
 		profile.GetPortrait(), stats)
+	d.Color = card.PortraitColorFromEnv()
 
 	if err := card.WriteAll("assets", d); err != nil {
 		log.Fatalf("write cards: %v", err)

--- a/cmd/gen/main.go
+++ b/cmd/gen/main.go
@@ -60,6 +60,7 @@ func main() {
 			Issues:       githubStats.Issues,
 			Contributed:  githubStats.Contributed,
 		})
+	cardData.Color = card.PortraitColorFromEnv()
 	if err := card.WriteAll("assets", cardData); err != nil {
 		log.Fatalf("Error writing profile card: %v", err)
 	}

--- a/internal/card/buttons.go
+++ b/internal/card/buttons.go
@@ -23,7 +23,7 @@ const (
 	btnIC   = 16.0
 	btnGap  = 8.0
 	btnPadR = 12.0
-	btnRX   = 6.0
+	btnRX   = ghRadius
 )
 
 // glyphAdv and glyphRSB are per-glyph metrics for SF Pro Text Medium — the font

--- a/internal/card/card.go
+++ b/internal/card/card.go
@@ -25,12 +25,40 @@ type Data struct {
 	Commits, PullRequests     int
 	Stars, Issues             int
 	Contributed               int
+	Color                     PortraitColor
 }
 
 // Stats is the subset of GitHub stats the card shows.
 type Stats struct {
 	Commits, PullRequests, Stars, Issues, Contributed int
 }
+
+// PortraitColor selects how the ASCII portrait is tinted, chosen via the
+// PORTRAIT_COLOR env var. ColorCycle animates between the yellow and gray
+// gradients and honors prefers-reduced-motion (holding on yellow).
+type PortraitColor string
+
+const (
+	ColorYellow PortraitColor = "yellow"
+	ColorGray   PortraitColor = "gray"
+	ColorCycle  PortraitColor = "cycle"
+)
+
+// ParsePortraitColor maps a PORTRAIT_COLOR value to a mode, defaulting to
+// ColorCycle for empty or unrecognized input.
+func ParsePortraitColor(s string) PortraitColor {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "yellow":
+		return ColorYellow
+	case "gray", "grey":
+		return ColorGray
+	default:
+		return ColorCycle
+	}
+}
+
+// PortraitColorFromEnv reads and parses the PORTRAIT_COLOR env var.
+func PortraitColorFromEnv() PortraitColor { return ParsePortraitColor(os.Getenv("PORTRAIT_COLOR")) }
 
 const (
 	padX     = 30.0
@@ -42,6 +70,7 @@ const (
 	bFS, bLH = 13.5, 19.0 // bio font-size / line-height
 	bCW      = 8.12
 	font     = "'SFMono-Regular','SF Mono',Consolas,'Liberation Mono',Menlo,monospace"
+	ghRadius = 6.0
 )
 
 type theme struct {
@@ -49,7 +78,7 @@ type theme struct {
 	name, host, topkey, subkey string
 	arrow, branch, value, dash string
 	prompt                     string
-	pg                         [3]string
+	pgY, pgG                   [3]string // portrait gradient: yellow / gray 3-stop sets
 }
 
 var themes = map[string]theme{
@@ -58,14 +87,16 @@ var themes = map[string]theme{
 		name: "#f47067", host: "#6cb6ff", topkey: "#d2a8ff", subkey: "#e3b341",
 		arrow: "#56d4dd", branch: "#39929e", value: "#adbac7", dash: "#444c56",
 		prompt: "#57ab5a",
-		pg:     [3]string{"#f47067", "#d2a8ff", "#6cb6ff"},
+		pgY:    [3]string{"#ffdf5d", "#e3b341", "#d29922"},
+		pgG:    [3]string{"#f0f6fc", "#c9d1d9", "#8b949e"},
 	},
 	"light": {
 		win: "#ffffff", bar: "#f6f8fa", border: "#d0d7de", title: "#57606a",
 		name: "#cf222e", host: "#0969da", topkey: "#8250df", subkey: "#9a6700",
 		arrow: "#1b7c83", branch: "#1b7c83", value: "#24292f", dash: "#d8dee4",
 		prompt: "#1a7f37",
-		pg:     [3]string{"#cf222e", "#8250df", "#0969da"},
+		pgY:    [3]string{"#d4a72c", "#bf8700", "#9a6700"},
+		pgG:    [3]string{"#57606a", "#424a53", "#24292f"},
 	},
 }
 
@@ -149,6 +180,11 @@ func Render(themeName string, d Data) string {
 	t := themes[themeName]
 	pl := d.Portrait
 
+	mode := d.Color
+	if mode != ColorYellow && mode != ColorGray {
+		mode = ColorCycle
+	}
+
 	nCols := 0
 	for _, l := range pl {
 		if len(l) > nCols {
@@ -211,18 +247,35 @@ func Render(themeName string, d Data) string {
 
 	p(fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="%d" viewBox="0 0 %d %d" font-family="%s" role="img" aria-label="%s@%s — git fetch profile card">`,
 		int(W), int(H), int(W), int(H), font, esc(d.Name), esc(d.Host)))
-	p(`<style>` +
+	style := `<style>` +
 		`@keyframes blink{50%{opacity:0}}.cur{animation:blink 1.1s step-end infinite}` +
 		`@keyframes fin{from{opacity:0}to{opacity:1}}.fade{animation:fin .8s ease both}` +
 		fmt.Sprintf(`.tk{fill:%s;font-weight:700}.sk{fill:%s}`, t.topkey, t.subkey) +
 		fmt.Sprintf(`.ar{fill:%s}.br{fill:%s}.vl{fill:%s}`, t.arrow, t.branch, t.value) +
-		`text,tspan{white-space:pre}` +
-		`</style>`)
-	p(fmt.Sprintf(`<defs><linearGradient id="pg" x1="0" y1="0" x2="0" y2="1">`+
-		`<stop offset="0" stop-color="%s"/><stop offset="0.5" stop-color="%s"/>`+
-		`<stop offset="1" stop-color="%s"/></linearGradient></defs>`, t.pg[0], t.pg[1], t.pg[2]))
-	p(fmt.Sprintf(`<rect x="0.5" y="0.5" width="%.0f" height="%.0f" rx="12" fill="%s" stroke="%s"/>`,
-		W-1, H-1, t.win, t.border))
+		`text,tspan{white-space:pre}`
+	if mode == ColorCycle {
+		// gray overlay cross-fades over the yellow base; reduced-motion holds on yellow
+		style += `@keyframes pgc{0%,100%{opacity:0}50%{opacity:1}}` +
+			`.pgc{animation:pgc 9s ease-in-out infinite}` +
+			`@media (prefers-reduced-motion:reduce){.pgc{animation:none;opacity:0}}`
+	}
+	p(style + `</style>`)
+
+	grad := func(id string, c [3]string) string {
+		return fmt.Sprintf(`<linearGradient id="%s" x1="0" y1="0" x2="0" y2="1">`+
+			`<stop offset="0" stop-color="%s"/><stop offset="0.5" stop-color="%s"/>`+
+			`<stop offset="1" stop-color="%s"/></linearGradient>`, id, c[0], c[1], c[2])
+	}
+	switch mode {
+	case ColorCycle:
+		p(`<defs>` + grad("pgY", t.pgY) + grad("pgG", t.pgG) + `</defs>`)
+	case ColorGray:
+		p(`<defs>` + grad("pg", t.pgG) + `</defs>`)
+	default: // static yellow
+		p(`<defs>` + grad("pg", t.pgY) + `</defs>`)
+	}
+	p(fmt.Sprintf(`<rect x="0.5" y="0.5" width="%.0f" height="%.0f" rx="%g" fill="%s" stroke="%s"/>`,
+		W-1, H-1, ghRadius, t.win, t.border))
 
 	// starship-style prompt line: ~ ❯ git fetch
 	p(fmt.Sprintf(`<text x="%.0f" y="%.1f" font-size="%g">`+
@@ -231,15 +284,31 @@ func Render(themeName string, d Data) string {
 		`<tspan fill="%s">git</tspan><tspan fill="%s"> fetch</tspan></text>`,
 		padX, promptBase, iFS, t.arrow, t.prompt, t.subkey, t.value))
 
-	p(fmt.Sprintf(`<g class="fade" fill="url(#pg)" font-size="%g">`, pFS))
-	py := pTop + pFS
-	for _, l := range pl {
-		if strings.TrimSpace(l) != "" {
-			p(fmt.Sprintf(`<text x="%.0f" y="%.1f">%s</text>`, padX, py, esc(l)))
+	drawPortrait := func() {
+		py := pTop + pFS
+		for _, l := range pl {
+			if strings.TrimSpace(l) != "" {
+				p(fmt.Sprintf(`<text x="%.0f" y="%.1f">%s</text>`, padX, py, esc(l)))
+			}
+			py += pLH
 		}
-		py += pLH
 	}
-	p(`</g>`)
+	if mode == ColorCycle {
+		// two stacked copies at identical positions: the gray overlay's opacity
+		// cross-fades (via .pgc) to morph between the two gradients.
+		p(fmt.Sprintf(`<g class="fade" font-size="%g">`, pFS))
+		p(`<g fill="url(#pgY)">`)
+		drawPortrait()
+		p(`</g>`)
+		p(`<g class="pgc" fill="url(#pgG)" opacity="0">`)
+		drawPortrait()
+		p(`</g>`)
+		p(`</g>`)
+	} else {
+		p(fmt.Sprintf(`<g class="fade" fill="url(#pg)" font-size="%g">`, pFS))
+		drawPortrait()
+		p(`</g>`)
+	}
 
 	p(fmt.Sprintf(`<g font-size="%g">`, iFS))
 	yy := bodyTop + iFS

--- a/templates/README.tmpl
+++ b/templates/README.tmpl
@@ -7,26 +7,11 @@
 </p>
 
 <p align="center">
-  <a href="{{.Profile.Links.Website.URL}}">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="./assets/btn_website_dark.svg" />
-      <img alt="{{.Profile.Links.Website.Label}}" src="./assets/btn_website_light.svg" height="32" />
-    </picture>
-  </a>
+  <a href="{{.Profile.Links.Website.URL}}"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/btn_website_dark.svg" /><img alt="{{.Profile.Links.Website.Label}}" src="./assets/btn_website_light.svg" height="32" /></picture></a>
   &nbsp;
-  <a href="{{.Profile.Links.LinkedIn.URL}}">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="./assets/btn_linkedin_dark.svg" />
-      <img alt="LinkedIn" src="./assets/btn_linkedin_light.svg" height="32" />
-    </picture>
-  </a>
+  <a href="{{.Profile.Links.LinkedIn.URL}}"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/btn_linkedin_dark.svg" /><img alt="LinkedIn" src="./assets/btn_linkedin_light.svg" height="32" /></picture></a>
   &nbsp;
-  <a href="mailto:{{.Profile.Email}}">
-    <picture>
-      <source media="(prefers-color-scheme: dark)" srcset="./assets/btn_email_dark.svg" />
-      <img alt="Email" src="./assets/btn_email_light.svg" height="32" />
-    </picture>
-  </a>
+  <a href="mailto:{{.Profile.Email}}"><picture><source media="(prefers-color-scheme: dark)" srcset="./assets/btn_email_dark.svg" /><img alt="Email" src="./assets/btn_email_light.svg" height="32" /></picture></a>
 </p>
 {{if .ShowPosts}}
 ## 📝 Latest Posts


### PR DESCRIPTION
## What

Adds a **`PORTRAIT_COLOR`** env var to tint the card's ASCII portrait, with three modes:

| Value | Result |
|---|---|
| `yellow` | static amber-yellow 3-stop gradient |
| `gray` | static gray 3-stop gradient (darker on white for contrast) |
| `cycle` *(default)* | smoothly animates the portrait between the yellow and gray gradients |

Unset / unrecognized input → `cycle` (`grey` accepted as an alias for `gray`).

## How

- `internal/card/card.go` — the `theme` now carries two 3-stop sets (`pgY` yellow / `pgG` gray). `Render` picks static `#pg` for `yellow`/`gray`, or emits two stacked portrait copies (yellow base + gray overlay) for `cycle`, cross-fading the overlay's opacity via a CSS `@keyframes`.
- **Reduced-motion:** the cycle animation is wrapped in `@media (prefers-reduced-motion: reduce)`, so those viewers get a still yellow portrait. Opacity-based cross-fade (not SMIL) keeps it robust in `<img>`-embedded SVGs and degrades to static yellow where animation isn't supported.
- `cmd/gen` and `cmd/cards` read the mode via `card.PortraitColorFromEnv()` (shared, not duplicated). Default `cycle` means the weekly CI regen keeps the animation with no workflow change.
- Regenerated `assets/{dark,light}_mode.svg` + `README.md`.

Also folds in the earlier theme-aware connect buttons (`buttons.go`) and the collapsed-anchor README fix (`templates/README.tmpl`).

## Notes

- Layout is unaffected by the double-draw: portrait height is `len(portrait) * pLH` regardless of draw count, so the two-pass measurement stays in sync.
- Ran `/code-review` at medium — no correctness findings.